### PR TITLE
[WIP] fall back to -no-client behavior if client CLI fails to launch

### DIFF
--- a/connector/connector.go
+++ b/connector/connector.go
@@ -70,10 +70,18 @@ func handleClient(
 		srv, found := service.GetService(si)
 		if found {
 			fmt.Println("Connecting client...")
-			return srv.Launch(tunnel.LocalPort, creds)
+			err := srv.Launch(tunnel.LocalPort, creds)
+			if err == nil {
+				// exited cleanly
+				return nil
+			}
+			fmt.Println("Unable to launch client CLI:")
+			fmt.Println(err)
+		} else {
+			fmt.Printf("Unable to find matching client for service '%s' with plan '%s'.\n", si.Service, si.Plan)
 		}
 
-		fmt.Printf("Unable to find matching client for service '%s' with plan '%s'. Falling back to `-no-client` behavior.\n", si.Service, si.Plan)
+		fmt.Println("Falling back to `-no-client` behavior.")
 	}
 
 	return manualConnect(tunnel, creds)


### PR DESCRIPTION
Closes #19.

This is simpler and more comprehensive than checking for the existence of each of the values we pass through, and should catch all of the same errors (though not with the same granularity).

Trying to figure out how best to test this. @jmcarp @jcscottiii Thoughts?