### PR TITLE
add S3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Requires Diego architecture with [SSH enabled](https://docs.cloudfoundry.org/run
 
 Currently supports (most) service brokers for the following:
 
+* AWS S3 (requires [`aws-shell`](https://github.com/awslabs/aws-shell))
 * MongoDB (requires [`mongo` shell](https://docs.mongodb.com/getting-started/shell/installation/))
 * MySQL (requires [`mysql` CLI](https://dev.mysql.com/doc/refman/8.0/en/installing.html))
 * PostgreSQL (requires [`psql` CLI](https://postgresapp.com/documentation/cli-tools.html))

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -105,7 +105,10 @@ func Connect(cliConnection plugin.CliConnection, options Options) (err error) {
 	}
 
 	fmt.Println("Setting up SSH tunnel...")
-	tunnel := launcher.NewSSHTunnel(creds, options.AppName)
+	tunnel, err := launcher.NewSSHTunnel(creds, options.AppName)
+	if err != nil {
+		return
+	}
 	err = tunnel.Open()
 	if err != nil {
 		return

--- a/launcher/ssh_tunnel.go
+++ b/launcher/ssh_tunnel.go
@@ -60,14 +60,18 @@ func (t *SSHTunnel) Close() error {
 }
 
 // NewSSHTunnel prepares the underlying Cloud Foundry CLI process for creating an SSH tunnel to a service instance.
-func NewSSHTunnel(creds models.Credentials, appName string) SSHTunnel {
+func NewSSHTunnel(creds models.Credentials, appName string) (SSHTunnel, error) {
 	localPort := getAvailablePort()
+	destPort, err := creds.GetPort()
+	if err != nil {
+		return SSHTunnel{}, err
+	}
 
 	cmd := execute(
 		"cf",
 		"ssh",
 		"-N",
-		"-L", fmt.Sprintf("%d:%s:%s", localPort, creds.GetHost(), creds.GetPort()),
+		"-L", fmt.Sprintf("%d:%s:%d", localPort, creds.GetHost(), destPort),
 		appName,
 	)
 	// should only print in the case of an issue
@@ -78,5 +82,5 @@ func NewSSHTunnel(creds models.Credentials, appName string) SSHTunnel {
 		LocalPort: localPort,
 		cmd:       cmd,
 		errChan:   make(chan error),
-	}
+	}, nil
 }

--- a/models/credentials.go
+++ b/models/credentials.go
@@ -21,6 +21,7 @@ type Credentials interface {
 	GetUsername() string
 	GetPassword() string
 	GetPort() (int, error)
+	GetRegion() string
 }
 
 // http://stackoverflow.com/a/28035946/358804
@@ -28,18 +29,23 @@ type credentialsJSON struct {
 	// these groups of fields should be interchangeable
 	DBName string `json:"db_name"`
 	Dbname string `json:"dbname"`
+	Bucket string `json:"bucket"`
 	Name   string `json:"name"`
 
 	Host     string `json:"host"`
 	Hostname string `json:"hostname"`
 	HostName string `json:"host_name"`
 
-	Username string `json:"username"`
-	UserName string `json:"user_name"`
-	User     string `json:"user"`
+	Username    string `json:"username"`
+	UserName    string `json:"user_name"`
+	AccessKeyId string `json:"access_key_id"`
+	User        string `json:"user"`
 
-	Password string `json:"password"`
-	Pass     string `json:"pass"`
+	Password        string `json:"password"`
+	SecretAccessKey string `json:"secret_access_key"`
+	Pass            string `json:"pass"`
+
+	Region string `json:"region"`
 	///////////////////////////////////////////////////
 
 	// can be an integer or a string
@@ -53,6 +59,9 @@ func (c credentialsJSON) GetDBName() string {
 	}
 	if c.Dbname != "" {
 		return c.Dbname
+	}
+	if c.Bucket != "" {
+		return c.Bucket
 	}
 	return c.DBName
 }
@@ -74,6 +83,9 @@ func (c credentialsJSON) GetUsername() string {
 	if c.UserName != "" {
 		return c.UserName
 	}
+	if c.AccessKeyId != "" {
+		return c.AccessKeyId
+	}
 	return c.User
 }
 
@@ -81,11 +93,23 @@ func (c credentialsJSON) GetPassword() string {
 	if c.Pass != "" {
 		return c.Pass
 	}
+	if c.SecretAccessKey != "" {
+		return c.SecretAccessKey
+	}
 	return c.Password
 }
 
 func (c credentialsJSON) GetPort() (int, error) {
-	return strconv.Atoi(c.Port.String())
+	portStr := c.Port.String()
+	if portStr == "" {
+		// TODO think of a better way to handle this
+		return 0, nil
+	}
+	return strconv.Atoi(portStr)
+}
+
+func (c credentialsJSON) GetRegion() string {
+	return c.Region
 }
 
 func CredentialsFromJSON(body string) (creds Credentials, err error) {

--- a/models/credentials.go
+++ b/models/credentials.go
@@ -1,6 +1,9 @@
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strconv"
+)
 
 type serviceKeyResponse struct {
 	Resources []serviceKeyResource `json:"resources"`
@@ -17,7 +20,7 @@ type Credentials interface {
 	GetHost() string
 	GetUsername() string
 	GetPassword() string
-	GetPort() string
+	GetPort() (int, error)
 }
 
 // http://stackoverflow.com/a/28035946/358804
@@ -81,8 +84,8 @@ func (c credentialsJSON) GetPassword() string {
 	return c.Password
 }
 
-func (c credentialsJSON) GetPort() string {
-	return c.Port.String()
+func (c credentialsJSON) GetPort() (int, error) {
+	return strconv.Atoi(c.Port.String())
 }
 
 func CredentialsFromJSON(body string) (creds Credentials, err error) {

--- a/models/credentials_test.go
+++ b/models/credentials_test.go
@@ -84,6 +84,21 @@ func TestCredentialsFromJSON(t *testing.T) {
 			"user",
 			"pass",
 		},
+		{
+			`{
+				"access_key_id": "mykey",
+				"additional_buckets": [],
+				"bucket": "mybucket",
+				"region": "us-gov-west-1",
+				"secret_access_key": "mysecret",
+				"uri": "s3://mykey:mysecret@s3-us-gov-west-1.amazonaws.com/mybucket"
+			}`,
+			"",
+			0,
+			"mybucket",
+			"mykey",
+			"mysecret",
+		},
 	}
 
 	for _, test := range tests {

--- a/models/credentials_test.go
+++ b/models/credentials_test.go
@@ -20,7 +20,7 @@ const JSONWrap = `{
 type credentialsFromJSONTest struct {
 	entityJSON     string
 	expectedHost   string
-	expectedPort   string
+	expectedPort   int
 	expectedDBName string
 	expectedUser   string
 	expectedPass   string
@@ -37,7 +37,7 @@ func TestCredentialsFromJSON(t *testing.T) {
 				"password": "pass"
 			}`,
 			"host.com",
-			"5432",
+			5432,
 			"name",
 			"user",
 			"pass",
@@ -51,7 +51,7 @@ func TestCredentialsFromJSON(t *testing.T) {
 				"pass": "pass"
 			}`,
 			"host.com",
-			"5432",
+			5432,
 			"name",
 			"user",
 			"pass",
@@ -65,7 +65,7 @@ func TestCredentialsFromJSON(t *testing.T) {
 				"password": "pass"
 			}`,
 			"host.com",
-			"5432",
+			5432,
 			"name",
 			"user",
 			"pass",
@@ -79,7 +79,7 @@ func TestCredentialsFromJSON(t *testing.T) {
 				"password": "pass"
 			}`,
 			"host.com",
-			"5432",
+			5432,
 			"name",
 			"user",
 			"pass",
@@ -92,7 +92,9 @@ func TestCredentialsFromJSON(t *testing.T) {
 		assert.Nil(t, err)
 
 		assert.Equal(t, creds.GetHost(), test.expectedHost)
-		assert.Equal(t, creds.GetPort(), test.expectedPort)
+		port, err := creds.GetPort()
+		assert.NoError(t, err)
+		assert.Equal(t, port, test.expectedPort)
 		assert.Equal(t, creds.GetDBName(), test.expectedDBName)
 		assert.Equal(t, creds.GetUsername(), test.expectedUser)
 		assert.Equal(t, creds.GetPassword(), test.expectedPass)

--- a/service/s3.go
+++ b/service/s3.go
@@ -1,0 +1,30 @@
+package service
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/18F/cf-service-connect/launcher"
+	"github.com/18F/cf-service-connect/models"
+)
+
+type s3 struct{}
+
+func (p s3) Match(si models.ServiceInstance) bool {
+	return si.ContainsTerms("s3")
+}
+
+func (p s3) Launch(localPort int, creds models.Credentials) error {
+	// note that the port/tunnel isn't actually used
+
+	// shoved support for the AWS credentials style into the database style
+	os.Setenv("AWS_DEFAULT_REGION", creds.GetRegion())
+	os.Setenv("AWS_ACCESS_KEY_ID", creds.GetUsername())
+	os.Setenv("AWS_SECRET_ACCESS_KEY", creds.GetPassword())
+	fmt.Printf("Bucket: %s\n", creds.GetDBName())
+
+	return launcher.StartShell("aws-shell", []string{})
+}
+
+// S3 is the service singleton.
+var S3 = s3{}

--- a/service/s3_test.go
+++ b/service/s3_test.go
@@ -1,0 +1,43 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/18F/cf-service-connect/models"
+	"github.com/stretchr/testify/assert"
+)
+
+type s3MatchTest struct {
+	serviceName string
+	planName    string
+	expected    bool
+}
+
+func TestS3Match(t *testing.T) {
+	tests := []s3MatchTest{
+		{
+			"s3",
+			"shared",
+			true,
+		},
+		{
+			"aws",
+			"s3",
+			true,
+		},
+		{
+			"mysql",
+			"shared",
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		serviceInstance := models.ServiceInstance{
+			Service: test.serviceName,
+			Plan:    test.planName,
+		}
+		result := S3.Match(serviceInstance)
+		assert.Equal(t, result, test.expected)
+	}
+}

--- a/service/services.go
+++ b/service/services.go
@@ -12,6 +12,7 @@ var services = []Service{
 	MySQL,
 	PSQL,
 	Redis,
+	S3,
 }
 
 func GetService(si models.ServiceInstance) (Service, bool) {


### PR DESCRIPTION
This pull request allows the user to connect to an S3 bucket managed by a Cloud Foundry service, as shown below:

<img width="725" alt="screen shot 2017-12-31 at 12 56 42 pm" src="https://user-images.githubusercontent.com/86842/34463441-0bf5e72e-ee2a-11e7-8909-fe658f298041.png">

It works, but there are some improvements that could be made:

* An SSH tunnel is created unneccessarily (assuming bucket access isn't [restricted to a VPC](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies-vpc-endpoint.html#example-bucket-policies-restrict-access-vpc))
* Using `-no-client` with an S3 service could output the information in a more AWS-specific way (not referring to the secret access key as a the "password", etc.)