### PR TITLE
gracefully handle the REPL being missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,14 @@ Requires Diego architecture with [SSH enabled](https://docs.cloudfoundry.org/run
 
 Currently supports (most) service brokers for the following:
 
-* MongoDB (requires [`mongo` shell](https://docs.mongodb.com/getting-started/shell/installation/))
-* MySQL (requires [`mysql` CLI](https://dev.mysql.com/doc/refman/8.0/en/installing.html))
-* PostgreSQL (requires [`psql` CLI](https://postgresapp.com/documentation/cli-tools.html))
-* Redis (requires [`redis-cli`](https://redis.io/topics/quickstart))
+Service | REPL
+--- | ---
+MongoDB | [`mongo` shell](https://docs.mongodb.com/getting-started/shell/installation/)
+MySQL | [`mysql` CLI](https://dev.mysql.com/doc/refman/8.0/en/installing.html)
+PostgreSQL | [`psql` CLI](https://postgresapp.com/documentation/cli-tools.html)
+Redis | [`redis-cli`](https://redis.io/topics/quickstart)
+
+If the corresponding REPL is installed on your system, the REPL will be started and connected to your service. Otherwise, connection instructions will be printed out.
 
 ## Local installation
 

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -3,6 +3,7 @@ package connector
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"text/template"
 
 	"github.com/18F/cf-service-connect/launcher"
@@ -83,8 +84,14 @@ func handleClient(
 	if options.ConnectClient {
 		if srv.HasRepl() {
 			cmd := srv.GetLaunchCmd(tunnel.LocalPort, creds)
-			fmt.Println("Connecting client...")
-			return cmd.Exec()
+			// check whether the executable is available
+			_, err := exec.LookPath(cmd.Cmd)
+			if err == nil {
+				fmt.Println("Connecting client...")
+				return cmd.Exec()
+			} else {
+				fmt.Printf("Executable `%s` not found.\n", cmd.Cmd)
+			}
 		}
 
 		fmt.Println("Falling back to `-no-client` behavior.")

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -70,7 +70,8 @@ func handleClient(
 		srv, found := service.GetService(si)
 		if found {
 			fmt.Println("Connecting client...")
-			return srv.Launch(tunnel.LocalPort, creds)
+			cmd := srv.GetLaunchCmd(tunnel.LocalPort, creds)
+			return cmd.Exec()
 		}
 
 		fmt.Printf("Unable to find matching client for service '%s' with plan '%s'. Falling back to `-no-client` behavior.\n", si.Service, si.Plan)

--- a/service/launch_cmd.go
+++ b/service/launch_cmd.go
@@ -1,0 +1,24 @@
+package service
+
+import (
+	"os"
+
+	"github.com/18F/cf-service-connect/launcher"
+)
+
+type LaunchCmd struct {
+	Envs map[string]string
+	Cmd  string
+	Args []string
+}
+
+func (lc LaunchCmd) Exec() error {
+	for envVar, val := range lc.Envs {
+		err := os.Setenv(envVar, val)
+		if err != nil {
+			return err
+		}
+	}
+
+	return launcher.StartShell(lc.Cmd, lc.Args)
+}

--- a/service/launch_cmd.go
+++ b/service/launch_cmd.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"os"
+	"strings"
 
 	"github.com/18F/cf-service-connect/launcher"
 )
@@ -21,4 +22,16 @@ func (lc LaunchCmd) Exec() error {
 	}
 
 	return launcher.StartShell(lc.Cmd, lc.Args)
+}
+
+func (lc LaunchCmd) String() string {
+	result := ""
+	for envVar, val := range lc.Envs {
+		result += envVar + "=" + val + " "
+	}
+	result += lc.Cmd
+	if len(lc.Args) > 0 {
+		result += " " + strings.Join(lc.Args, " ")
+	}
+	return result
 }

--- a/service/launch_cmd_test.go
+++ b/service/launch_cmd_test.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/bruth/assert"
+)
+
+type launchCmdStringTest struct {
+	LaunchCmd LaunchCmd
+	Expected  string
+}
+
+func TestLaunchCmdString(t *testing.T) {
+	tests := []launchCmdStringTest{
+		launchCmdStringTest{
+			LaunchCmd: LaunchCmd{
+				Cmd: "foo",
+			},
+			Expected: "foo",
+		},
+		launchCmdStringTest{
+			LaunchCmd: LaunchCmd{
+				Envs: map[string]string{
+					"a": "1",
+					"b": "2",
+				},
+				Cmd: "foo",
+			},
+			Expected: "a=1 b=2 foo",
+		},
+		launchCmdStringTest{
+			LaunchCmd: LaunchCmd{
+				Cmd:  "foo",
+				Args: []string{"bar", "baz"},
+			},
+			Expected: "foo bar baz",
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.LaunchCmd.String(), test.Expected)
+	}
+}

--- a/service/mongo_db.go
+++ b/service/mongo_db.go
@@ -12,6 +12,10 @@ func (p mongoDB) Match(si models.ServiceInstance) bool {
 	return si.ContainsTerms("mongo")
 }
 
+func (p mongoDB) HasRepl() bool {
+	return true
+}
+
 func (p mongoDB) GetLaunchCmd(localPort int, creds models.Credentials) LaunchCmd {
 	return LaunchCmd{
 		Cmd: "mongo",

--- a/service/mongo_db.go
+++ b/service/mongo_db.go
@@ -3,7 +3,6 @@ package service
 import (
 	"strconv"
 
-	"github.com/18F/cf-service-connect/launcher"
 	"github.com/18F/cf-service-connect/models"
 )
 
@@ -13,13 +12,16 @@ func (p mongoDB) Match(si models.ServiceInstance) bool {
 	return si.ContainsTerms("mongo")
 }
 
-func (p mongoDB) Launch(localPort int, creds models.Credentials) error {
-	return launcher.StartShell("mongo", []string{
-		"-u", creds.GetUsername(),
-		"-p", creds.GetPassword(),
-		"--port", strconv.Itoa(localPort),
-		creds.GetDBName(),
-	})
+func (p mongoDB) GetLaunchCmd(localPort int, creds models.Credentials) LaunchCmd {
+	return LaunchCmd{
+		Cmd: "mongo",
+		Args: []string{
+			"-u", creds.GetUsername(),
+			"-p", creds.GetPassword(),
+			"--port", strconv.Itoa(localPort),
+			creds.GetDBName(),
+		},
+	}
 }
 
 // MongoDB is the service singleton.

--- a/service/mysql.go
+++ b/service/mysql.go
@@ -3,7 +3,6 @@ package service
 import (
 	"strconv"
 
-	"github.com/18F/cf-service-connect/launcher"
 	"github.com/18F/cf-service-connect/models"
 )
 
@@ -13,14 +12,17 @@ func (p mySQL) Match(si models.ServiceInstance) bool {
 	return si.ContainsTerms("mysql")
 }
 
-func (p mySQL) Launch(localPort int, creds models.Credentials) error {
-	return launcher.StartShell("mysql", []string{
-		"-u", creds.GetUsername(),
-		"-h", "0",
-		"-p" + creds.GetPassword(),
-		"-D", creds.GetDBName(),
-		"-P", strconv.Itoa(localPort),
-	})
+func (p mySQL) GetLaunchCmd(localPort int, creds models.Credentials) LaunchCmd {
+	return LaunchCmd{
+		Cmd: "mysql",
+		Args: []string{
+			"-u", creds.GetUsername(),
+			"-h", "0",
+			"-p" + creds.GetPassword(),
+			"-D", creds.GetDBName(),
+			"-P", strconv.Itoa(localPort),
+		},
+	}
 }
 
 // MySQL is the service singleton.

--- a/service/mysql.go
+++ b/service/mysql.go
@@ -12,6 +12,10 @@ func (p mySQL) Match(si models.ServiceInstance) bool {
 	return si.ContainsTerms("mysql")
 }
 
+func (p mySQL) HasRepl() bool {
+	return true
+}
+
 func (p mySQL) GetLaunchCmd(localPort int, creds models.Credentials) LaunchCmd {
 	return LaunchCmd{
 		Cmd: "mysql",

--- a/service/psql.go
+++ b/service/psql.go
@@ -2,10 +2,7 @@ package service
 
 import (
 	"fmt"
-	"os"
 
-	"github.com/18F/cf-service-connect/launcher"
-	"github.com/18F/cf-service-connect/logger"
 	"github.com/18F/cf-service-connect/models"
 )
 
@@ -15,16 +12,19 @@ func (p pSQL) Match(si models.ServiceInstance) bool {
 	return si.ContainsTerms("psql", "postgres")
 }
 
-func (p pSQL) Launch(localPort int, creds models.Credentials) error {
-	os.Setenv("PGPASSWORD", creds.GetPassword())
-	logger.Debugf("PGPASSWORD=%s ", creds.GetPassword())
-
-	return launcher.StartShell("psql", []string{
-		"-h", "localhost",
-		"-p", fmt.Sprintf("%d", localPort),
-		creds.GetDBName(),
-		creds.GetUsername(),
-	})
+func (p pSQL) GetLaunchCmd(localPort int, creds models.Credentials) LaunchCmd {
+	return LaunchCmd{
+		Envs: map[string]string{
+			"PGPASSWORD": creds.GetPassword(),
+		},
+		Cmd: "psql",
+		Args: []string{
+			"-h", "localhost",
+			"-p", fmt.Sprintf("%d", localPort),
+			creds.GetDBName(),
+			creds.GetUsername(),
+		},
+	}
 }
 
 // PSQL is the service singleton.

--- a/service/psql.go
+++ b/service/psql.go
@@ -12,6 +12,10 @@ func (p pSQL) Match(si models.ServiceInstance) bool {
 	return si.ContainsTerms("psql", "postgres")
 }
 
+func (p pSQL) HasRepl() bool {
+	return true
+}
+
 func (p pSQL) GetLaunchCmd(localPort int, creds models.Credentials) LaunchCmd {
 	return LaunchCmd{
 		Envs: map[string]string{

--- a/service/redis.go
+++ b/service/redis.go
@@ -12,6 +12,10 @@ func (p redis) Match(si models.ServiceInstance) bool {
 	return si.ContainsTerms("redis")
 }
 
+func (p redis) HasRepl() bool {
+	return true
+}
+
 func (p redis) GetLaunchCmd(localPort int, creds models.Credentials) LaunchCmd {
 	return LaunchCmd{
 		Cmd: "redis-cli",

--- a/service/redis.go
+++ b/service/redis.go
@@ -3,7 +3,6 @@ package service
 import (
 	"strconv"
 
-	"github.com/18F/cf-service-connect/launcher"
 	"github.com/18F/cf-service-connect/models"
 )
 
@@ -13,11 +12,14 @@ func (p redis) Match(si models.ServiceInstance) bool {
 	return si.ContainsTerms("redis")
 }
 
-func (p redis) Launch(localPort int, creds models.Credentials) error {
-	return launcher.StartShell("redis-cli", []string{
-		"-p", strconv.Itoa(localPort),
-		"-a", creds.GetPassword(),
-	})
+func (p redis) GetLaunchCmd(localPort int, creds models.Credentials) LaunchCmd {
+	return LaunchCmd{
+		Cmd: "redis-cli",
+		Args: []string{
+			"-p", strconv.Itoa(localPort),
+			"-a", creds.GetPassword(),
+		},
+	}
 }
 
 // Redis is the service singleton.

--- a/service/services.go
+++ b/service/services.go
@@ -4,6 +4,7 @@ import "github.com/18F/cf-service-connect/models"
 
 type Service interface {
 	Match(si models.ServiceInstance) bool
+	HasRepl() bool
 	GetLaunchCmd(localPort int, creds models.Credentials) LaunchCmd
 }
 
@@ -14,12 +15,12 @@ var services = []Service{
 	Redis,
 }
 
-func GetService(si models.ServiceInstance) (Service, bool) {
+func GetService(si models.ServiceInstance) Service {
 	for _, potentialService := range services {
 		if potentialService.Match(si) {
-			return potentialService, true
+			return potentialService
 		}
 	}
 
-	return nil, false
+	return UnknownService
 }

--- a/service/services.go
+++ b/service/services.go
@@ -4,7 +4,7 @@ import "github.com/18F/cf-service-connect/models"
 
 type Service interface {
 	Match(si models.ServiceInstance) bool
-	Launch(localPort int, creds models.Credentials) error
+	GetLaunchCmd(localPort int, creds models.Credentials) LaunchCmd
 }
 
 var services = []Service{

--- a/service/services_test.go
+++ b/service/services_test.go
@@ -10,7 +10,6 @@ import (
 type getServiceTest struct {
 	serviceName   string
 	planName      string
-	expectFound   bool
 	expectService Service
 }
 
@@ -19,20 +18,17 @@ func TestGetService(t *testing.T) {
 		{
 			"psql",
 			"shared",
-			true,
 			PSQL,
 		},
 		{
 			"mysql",
 			"shared",
-			true,
 			MySQL,
 		},
 		{
 			"other",
 			"service",
-			false,
-			nil,
+			UnknownService,
 		},
 	}
 
@@ -41,11 +37,8 @@ func TestGetService(t *testing.T) {
 			Service: test.serviceName,
 			Plan:    test.planName,
 		}
-		srv, found := GetService(serviceInstance)
-		assert.Equal(t, found, test.expectFound)
-		if test.expectFound {
-			assert.Equal(t, srv, test.expectService)
-		}
+		srv := GetService(serviceInstance)
+		assert.Equal(t, srv, test.expectService)
 	}
 
 }

--- a/service/unknown_service.go
+++ b/service/unknown_service.go
@@ -1,0 +1,26 @@
+package service
+
+import (
+	"github.com/18F/cf-service-connect/models"
+)
+
+type unknownService struct{}
+
+func (p unknownService) Match(si models.ServiceInstance) bool {
+	return true
+}
+
+func (p unknownService) HasRepl() bool {
+	return false
+}
+
+func (p unknownService) GetLaunchCmd(localPort int, creds models.Credentials) LaunchCmd {
+	return LaunchCmd{
+		// no-op
+		// https://stackoverflow.com/a/12405621/358804
+		Cmd: ":",
+	}
+}
+
+// UnknownService is the service singleton.
+var UnknownService = unknownService{}


### PR DESCRIPTION
Closes #48. Builds on #44 - [diff](https://github.com/18F/cf-service-connect/compare/manual-usage...check-repl).

If the REPL corresponding to the desired service can't be found, fall back to -no-client behavior.

```
$ which psql
psql not found
$ cf connect-to-service myapp mydb
Finding the service instance details...
Setting up SSH tunnel...
SSH tunnel created.
Executable `psql` not found.
Falling back to `-no-client` behavior.
Skipping call to client CLI. Connection information:

Host: localhost
Port: 58923
Username: myuser
Password: mypass
Name: dbname

To connect:

    PGPASSWORD=mypass psql -h localhost -p 58923 dbname myuser

Leave this terminal open while you want to use the SSH tunnel. Press Control-C to stop.
```