### PR TITLE
Add minor clarification to what plugin use when using OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Currently supports (most) service brokers for the following:
 
 ## Local installation
 
-1. Install the [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) v6.15.0 or later. 
+1. Install the [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) v6.15.0 or later.
 2. Install this plugin, using the appropriate binary URL from [the Releases page](https://github.com/18F/cf-service-connect/releases).
 
     ```sh

--- a/README.md
+++ b/README.md
@@ -17,16 +17,18 @@ Currently supports (most) service brokers for the following:
 
 ## Local installation
 
-1. Install the [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) v6.15.0 or later.
-1. Install this plugin, using the appropriate binary URL from [the Releases page](https://github.com/18F/cf-service-connect/releases).
+1. Install the [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) v6.15.0 or later. 
+2. Install this plugin, using the appropriate binary URL from [the Releases page](https://github.com/18F/cf-service-connect/releases).
 
     ```sh
     cf install-plugin <binary_url>
     # will be of the format
     # https://github.com/18F/cf-service-connect/releases/download/<version>/cf-service-connect.<os>
+    # For OSX use cf-service-connect-darwin-xxx
+
     ```
 
-1. Install the CLI corresponding to your service type (see above).
+3. Install the CLI corresponding to your service type (see above).
 
 ## Usage
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Clarification to the README and what plugin use when using OSX os.

## Security considerations

- None.

[Note the any security considerations here, or make note of why there are none]
