### PR TITLE
Add minor clarification to what plugin use when using OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,16 @@ Currently supports (most) service brokers for the following:
 ## Local installation
 
 1. Install the [Cloud Foundry CLI](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) v6.15.0 or later.
-1. Install this plugin, using the appropriate binary URL from [the Releases page](https://github.com/18F/cf-service-connect/releases).
+2. Install this plugin, using the appropriate binary URL from [the Releases page](https://github.com/18F/cf-service-connect/releases).
 
     ```sh
     cf install-plugin <binary_url>
     # will be of the format
     # https://github.com/18F/cf-service-connect/releases/download/<version>/cf-service-connect.<os>
+    # For OSX use cf-service-connect-darwin-xxx
     ```
 
-1. Install the CLI corresponding to your service type (see above).
+3. Install the CLI corresponding to your service type (see above).
 
 ## Usage
 


### PR DESCRIPTION
Merge in contributions #62 and #63

## Changes proposed in this pull request:

Remove blank space

Add comment to clarify version for OSX

## Security considerations

None, documentation updates
