### PR TITLE
add --tls flag by default for redis client & add unit test

### DIFF
--- a/service/redis.go
+++ b/service/redis.go
@@ -14,10 +14,15 @@ func (p redis) Match(si models.ServiceInstance) bool {
 }
 
 func (p redis) Launch(localPort int, creds models.Credentials) error {
-	return launcher.StartShell("redis-cli", []string{
+	return launcher.StartShell("redis-cli", getRedisLaunchFlags(localPort, creds))
+}
+
+func getRedisLaunchFlags(localPort int, creds models.Credentials) []string {
+	return []string{
+		"--tls",
 		"-p", strconv.Itoa(localPort),
 		"-a", creds.GetPassword(),
-	})
+	}
 }
 
 // Redis is the service singleton.

--- a/service/redis_test.go
+++ b/service/redis_test.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/18F/cf-service-connect/models"
@@ -11,6 +13,30 @@ type redisMatchTest struct {
 	serviceName string
 	planName    string
 	expected    bool
+}
+
+type mockCredentials struct {
+	mockPassword string
+}
+
+func (m mockCredentials) GetPassword() string {
+	return m.mockPassword
+}
+
+func (m mockCredentials) GetDBName() string {
+	return ""
+}
+
+func (m mockCredentials) GetUsername() string {
+	return ""
+}
+
+func (m mockCredentials) GetHost() string {
+	return ""
+}
+
+func (m mockCredentials) GetPort() string {
+	return ""
 }
 
 func TestRedisMatch(t *testing.T) {
@@ -44,5 +70,20 @@ func TestRedisMatch(t *testing.T) {
 		}
 		result := Redis.Match(serviceInstance)
 		assert.Equal(t, result, test.expected)
+	}
+}
+
+func TestGetRedisLaunchFlags(t *testing.T) {
+	mockCredentialsClient := &mockCredentials{
+		mockPassword: "fake-password",
+	}
+	flags := getRedisLaunchFlags(53839, mockCredentialsClient)
+	expectedFlags := []string{
+		"--tls",
+		"-p", strconv.Itoa(53839),
+		"-a", "fake-password",
+	}
+	if !reflect.DeepEqual(flags, expectedFlags) {
+		t.Fatalf("expected: %s, got: %s", expectedFlags, flags)
 	}
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- add `--tls` flag by default for redis client
- add unit test

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

The TLS flag is necessary for connecting to our Redis instances because they are all configured to use TLS, as documented here: https://cloud.gov/docs/services/aws-elasticache/#connecting-to-your-elasticache-service-locally
