### PR TITLE
Update release pipeline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,8 @@ This will (re)install then run the plugin, all in one.
 ### Releasing
 
 1. Update `Version` in [`main.go`](main.go).
-1. Run `bin/create-release-binaries.sh` to [create cross-compiled binaries](https://github.com/cloudfoundry-incubator/cli-plugin-repo#cross-compile-to-the-3-different-operating-systems).
 1. Commit, tag, and push via Git.
-1. Upload the binaries to [the new Release](https://github.com/18F/cf-service-connect/releases).
+1. The `cf-service-connect` Concourse pipeline should then detect the new tag and automatically:
+  
+    - Test the changes
+    - Create a new GitHub release including the generated release binaries (see [bin/create-release-binaries.sh](./bin/create-release-binaries.sh))

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ mysql>
 
 If you get an error such as "connection refused", "error opening SSH connection", or "psql: could not connect to server: Connection refused" this is usually caused by being on a network that blocks the SSH port that this tool is trying to use. Try using a different network, or consider asking your network administrator to unblock the port (typically 22 and/or 2222).
 
-### Note for Windows
+### Optional: overriding `cf` CLI binary name
 
 If you are in Windows or another environment where the Cloud Foundry CLI was installed as `cf7` or `cf8`, you can set an environment to tell the plugin what binary name to use for the Cloud Foundry CLI:
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -23,13 +23,13 @@ jobs:
       trigger: true
     - task: prepare-release
       file: cf-service-connect-repo/ci/prepare-release.yml
-    # - put: cf-service-connect-release
-    #   params:
-    #     name: cf-service-connect-repo/tag
-    #     tag: cf-service-connect-repo/tag
-    #     body: cf-service-connect-repo/releaselog.md
-    #     globs:
-    #       - cf-service-connect-repo/cf-service-connect_*
+    - put: cf-service-connect-release
+      params:
+        name: cf-service-connect-repo/tag
+        tag: cf-service-connect-repo/tag
+        generate_release_notes: true
+        globs:
+          - cf-service-connect-repo/cf-service-connect_*
   on_failure:
     put: slack
     params:
@@ -67,12 +67,12 @@ resources:
     url: ((slack-webhook-url))
 
 # Resource for creating a new release
-# - name: cf-service-connect-release
-#   type: github-release
-#   source:
-#     owner: cloud-gov
-#     repository: cf-service-connect
-#     access_token: ((cg-ci-bot-ghtoken))
+- name: cf-service-connect-release
+  type: github-release
+  source:
+    owner: cloud-gov
+    repository: cf-service-connect
+    access_token: ((cg-ci-bot-ghtoken))
 
 resource_types:
 

--- a/ci/prepare-release.sh
+++ b/ci/prepare-release.sh
@@ -3,8 +3,5 @@
 TAG=$(git describe --tags)
 echo "$TAG" > tag
 
-LAST_TAG=$(git describe --tags --abbrev=0)
-git log "$LAST_TAG..HEAD" --oneline --no-decorate > releaselog.md
-
 # Create release binaries
 ./bin/create-release-binaries.sh


### PR DESCRIPTION
## Changes proposed in this pull request:

- Enable pipeline step for creating GitHub release
- Update documentation

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
