### PR TITLE
Added PowerShell instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ If you are in Windows or another environment where the Cloud Foundry CLI was ins
 CF_BINARY_NAME=cf7 cf connect-to-service <app_name> <service_instance_name>
 ```
 
+Or in PowerShell:
+```
+$env:CF_BINARY_NAME = "cf7";
+cf7 connect-to-service <app_name> <service_instance_name>
+```
+
 ### Manual client connection
 
 If you're using a non-default client (such as a GUI), run with the `-no-client` option to set up your client connection on your own.


### PR DESCRIPTION
Added PowerShell-specific instructions for how to override the cf CLI binary name to the README

## Changes proposed in this pull request:

- Include instructions for updating the CF_BINARY_NAME environment variable in PowerShell.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
