### PR TITLE
set branch name in file

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -30,6 +30,7 @@ jobs:
         params:
           name: cf-service-connect-repo/tag
           tag: cf-service-connect-repo/tag
+          commitish: cf-service-connect-repo/branch-name
           generate_release_notes: true
           globs:
             - cf-service-connect-repo/cf-service-connect_*

--- a/ci/prepare-release.sh
+++ b/ci/prepare-release.sh
@@ -3,5 +3,7 @@
 TAG=$(git describe --tags)
 echo "$TAG" > tag
 
+echo "main" > branch-name
+
 # Create release binaries
 ./bin/create-release-binaries.sh


### PR DESCRIPTION
## Changes proposed in this pull request:

- Set branch name for create-release job to use

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

set branch name
