### PR TITLE
use files from git resource

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -28,8 +28,9 @@ jobs:
         file: cf-service-connect-repo/ci/prepare-release.yml
       - put: cf-service-connect-release
         params:
-          name: cf-service-connect-repo/tag
-          tag: cf-service-connect-repo/tag
+          name: cf-service-connect-repo/.git/ref
+          tag: cf-service-connect-repo/.git/ref
+          commitish: cf-service-connect-repo/.git/HEAD
           generate_release_notes: true
           globs:
             - cf-service-connect-repo/cf-service-connect_*

--- a/ci/prepare-release.sh
+++ b/ci/prepare-release.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
 
-TAG=$(git describe --tags)
-echo "$TAG" > tag
-
 # Create release binaries
 ./bin/create-release-binaries.sh


### PR DESCRIPTION
## Changes proposed in this pull request:

- Use the files from the git resource to populate the name, tag, and commitish params
- Remove tag file

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Use the files already generated by the resource rather than setting a file ourselves
